### PR TITLE
Remove unnecessary require

### DIFF
--- a/lib/octospy.rb
+++ b/lib/octospy.rb
@@ -1,4 +1,3 @@
-require 'awesome_print'
 require 'cinch'
 require 'octokit'
 require 'dotenv'


### PR DESCRIPTION
`'awesome_print'` is not used for production code, I guess...

Currently awesome_print raises this error:

```
/Users/.../.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/octospy-0.0.8/lib/octospy.rb:1:in `require': cannot load such file -- awesome_print (LoadError)
```
